### PR TITLE
updated description for feature_evpn

### DIFF
--- a/docs/data-sources/feature_evpn.md
+++ b/docs/data-sources/feature_evpn.md
@@ -3,13 +3,13 @@
 page_title: "nxos_feature_evpn Data Source - terraform-provider-nxos"
 subcategory: ""
 description: |-
-  This data source can read the EVPN feature configuration.
+  This data source can read the EVPN feature (aka nv overlay evpn) configuration.
   API Documentation: fmEvpn https://pubhub.devnetcloud.com/media/dme-docs-10-2-2/docs/Feature%20Management/fm:Evpn/
 ---
 
 # nxos_feature_evpn (Data Source)
 
-This data source can read the EVPN feature configuration.
+This data source can read the EVPN feature (aka nv overlay evpn) configuration.
 
 - API Documentation: [fmEvpn](https://pubhub.devnetcloud.com/media/dme-docs-10-2-2/docs/Feature%20Management/fm:Evpn/)
 

--- a/docs/resources/feature_evpn.md
+++ b/docs/resources/feature_evpn.md
@@ -3,13 +3,13 @@
 page_title: "nxos_feature_evpn Resource - terraform-provider-nxos"
 subcategory: ""
 description: |-
-  This resource can manage the EVPN feature configuration.
+  This resource can manage the EVPN feature (aka nv overlay evpn) configuration.
   API Documentation: fmEvpn https://pubhub.devnetcloud.com/media/dme-docs-10-2-2/docs/Feature%20Management/fm:Evpn/
 ---
 
 # nxos_feature_evpn (Resource)
 
-This resource can manage the EVPN feature configuration.
+This resource can manage the EVPN feature (aka nv overlay evpn) configuration.
 
 - API Documentation: [fmEvpn](https://pubhub.devnetcloud.com/media/dme-docs-10-2-2/docs/Feature%20Management/fm:Evpn/)
 

--- a/gen/definitions/feature_evpn.yaml
+++ b/gen/definitions/feature_evpn.yaml
@@ -3,8 +3,8 @@ name: Feature EVPN
 class_name: fmEvpn
 dn: sys/fm/evpn
 no_delete: true
-ds_description: This data source can read the EVPN feature configuration.
-res_description: This resource can manage the EVPN feature configuration.
+ds_description: This data source can read the EVPN feature (aka nv overlay evpn) configuration.
+res_description: This resource can manage the EVPN feature (aka nv overlay evpn) configuration.
 doc_path: Feature%20Management/fm:Evpn/
 attributes:
   - nxos_name: adminSt

--- a/internal/provider/data_source_nxos_feature_evpn.go
+++ b/internal/provider/data_source_nxos_feature_evpn.go
@@ -19,7 +19,7 @@ type dataSourceFeatureEVPNType struct{}
 func (t dataSourceFeatureEVPNType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: helpers.NewResourceDescription("This data source can read the EVPN feature configuration.", "fmEvpn", "Feature%20Management/fm:Evpn/").String,
+		MarkdownDescription: helpers.NewResourceDescription("This data source can read the EVPN feature (aka nv overlay evpn) configuration.", "fmEvpn", "Feature%20Management/fm:Evpn/").String,
 
 		Attributes: map[string]tfsdk.Attribute{
 			"device": {

--- a/internal/provider/resource_nxos_feature_evpn.go
+++ b/internal/provider/resource_nxos_feature_evpn.go
@@ -20,7 +20,7 @@ type resourceFeatureEVPNType struct{}
 func (t resourceFeatureEVPNType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: helpers.NewResourceDescription("This resource can manage the EVPN feature configuration.", "fmEvpn", "Feature%20Management/fm:Evpn/").String,
+		MarkdownDescription: helpers.NewResourceDescription("This resource can manage the EVPN feature (aka nv overlay evpn) configuration.", "fmEvpn", "Feature%20Management/fm:Evpn/").String,
 
 		Attributes: map[string]tfsdk.Attribute{
 			"device": {


### PR DESCRIPTION
From the current description it is completely unclear what nxos_feature_evpn does. There is no "feature evpn" command.
So I updated the doc to mention that EVPN feature is actually command "nv overlay evpn"