### PR TITLE
fixed a typo in definitions

### DIFF
--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -33,6 +33,7 @@ resource "nxos_bgp" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `device` (String) A device name from the provider configuration.
 

--- a/docs/resources/bgp_instance.md
+++ b/docs/resources/bgp_instance.md
@@ -34,6 +34,7 @@ resource "nxos_bgp_instance" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `asn` (String) Autonomous system number.
 - `device` (String) A device name from the provider configuration.

--- a/docs/resources/default_qos_class_map.md
+++ b/docs/resources/default_qos_class_map.md
@@ -39,6 +39,7 @@ resource "nxos_default_qos_class_map" "example" {
 
 - `device` (String) A device name from the provider configuration.
 - `match_type` (String) Match type.
+  - Choices: `match-any`, `match-all`, `match-first`
   - Default value: `match-all`
 
 ### Read-Only

--- a/docs/resources/default_qos_policy_map.md
+++ b/docs/resources/default_qos_policy_map.md
@@ -39,6 +39,7 @@ resource "nxos_default_qos_policy_map" "example" {
 
 - `device` (String) A device name from the provider configuration.
 - `match_type` (String) Match type.
+  - Choices: `match-any`, `match-all`, `match-first`
   - Default value: `match-all`
 
 ### Read-Only

--- a/docs/resources/feature_bfd.md
+++ b/docs/resources/feature_bfd.md
@@ -27,6 +27,7 @@ resource "nxos_feature_bfd" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_bgp.md
+++ b/docs/resources/feature_bgp.md
@@ -27,6 +27,7 @@ resource "nxos_feature_bgp" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_dhcp.md
+++ b/docs/resources/feature_dhcp.md
@@ -27,6 +27,7 @@ resource "nxos_feature_dhcp" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_evpn.md
+++ b/docs/resources/feature_evpn.md
@@ -27,6 +27,7 @@ resource "nxos_feature_evpn" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_hmm.md
+++ b/docs/resources/feature_hmm.md
@@ -27,6 +27,7 @@ resource "nxos_feature_hmm" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_hsrp.md
+++ b/docs/resources/feature_hsrp.md
@@ -27,6 +27,7 @@ resource "nxos_feature_hsrp" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_interface_vlan.md
+++ b/docs/resources/feature_interface_vlan.md
@@ -27,6 +27,7 @@ resource "nxos_feature_interface_vlan" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_isis.md
+++ b/docs/resources/feature_isis.md
@@ -27,6 +27,7 @@ resource "nxos_feature_isis" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_lacp.md
+++ b/docs/resources/feature_lacp.md
@@ -27,6 +27,7 @@ resource "nxos_feature_lacp" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_lldp.md
+++ b/docs/resources/feature_lldp.md
@@ -27,6 +27,7 @@ resource "nxos_feature_lldp" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_macsec.md
+++ b/docs/resources/feature_macsec.md
@@ -27,6 +27,7 @@ resource "nxos_feature_macsec" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_netflow.md
+++ b/docs/resources/feature_netflow.md
@@ -27,6 +27,7 @@ resource "nxos_feature_netflow" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_nv_overlay.md
+++ b/docs/resources/feature_nv_overlay.md
@@ -27,6 +27,7 @@ resource "nxos_feature_nv_overlay" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_ospf.md
+++ b/docs/resources/feature_ospf.md
@@ -27,6 +27,7 @@ resource "nxos_feature_ospf" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_ospfv3.md
+++ b/docs/resources/feature_ospfv3.md
@@ -27,6 +27,7 @@ resource "nxos_feature_ospfv3" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_pim.md
+++ b/docs/resources/feature_pim.md
@@ -27,6 +27,7 @@ resource "nxos_feature_pim" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_ptp.md
+++ b/docs/resources/feature_ptp.md
@@ -27,6 +27,7 @@ resource "nxos_feature_ptp" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_pvlan.md
+++ b/docs/resources/feature_pvlan.md
@@ -27,6 +27,7 @@ resource "nxos_feature_pvlan" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_ssh.md
+++ b/docs/resources/feature_ssh.md
@@ -27,6 +27,7 @@ resource "nxos_feature_ssh" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_tacacs.md
+++ b/docs/resources/feature_tacacs.md
@@ -27,6 +27,7 @@ resource "nxos_feature_tacacs" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_telnet.md
+++ b/docs/resources/feature_telnet.md
@@ -27,6 +27,7 @@ resource "nxos_feature_telnet" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_udld.md
+++ b/docs/resources/feature_udld.md
@@ -27,6 +27,7 @@ resource "nxos_feature_udld" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_vn_segment.md
+++ b/docs/resources/feature_vn_segment.md
@@ -27,6 +27,7 @@ resource "nxos_feature_vn_segment" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/feature_vpc.md
+++ b/docs/resources/feature_vpc.md
@@ -27,6 +27,7 @@ resource "nxos_feature_vpc" "example" {
 ### Required
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
 
 ### Optional
 

--- a/docs/resources/isis.md
+++ b/docs/resources/isis.md
@@ -34,6 +34,7 @@ resource "nxos_isis" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `device` (String) A device name from the provider configuration.
 

--- a/docs/resources/isis_instance.md
+++ b/docs/resources/isis_instance.md
@@ -44,6 +44,7 @@ resource "nxos_isis_instance" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `device` (String) A device name from the provider configuration.
 

--- a/docs/resources/isis_interface.md
+++ b/docs/resources/isis_interface.md
@@ -73,12 +73,16 @@ resource "nxos_isis_interface" "example" {
 - `authentication_key_l1` (String) Authentication Key for IS-IS on Level-1.
 - `authentication_key_l2` (String) Authentication Key for IS-IS on Level-2.
 - `authentication_type` (String) IS-IS Authentication-Type without specific level.
+  - Choices: `clear`, `md5`, `unknown`
   - Default value: `unknown`
 - `authentication_type_l1` (String) IS-IS Authentication-Type for Level-1.
+  - Choices: `clear`, `md5`, `unknown`
   - Default value: `unknown`
 - `authentication_type_l2` (String) IS-IS Authentication-Type for Level-2.
+  - Choices: `clear`, `md5`, `unknown`
   - Default value: `unknown`
 - `circuit_type` (String) Circuit type.
+  - Choices: `l1`, `l2`, `l12`
   - Default value: `l12`
 - `device` (String) A device name from the provider configuration.
 - `hello_interval` (Number) Hello interval.
@@ -100,6 +104,7 @@ resource "nxos_isis_interface" "example" {
   - Range: `3`-`1000`
   - Default value: `3`
 - `hello_padding` (String) Hello padding.
+  - Choices: `always`, `transient`, `never`
   - Default value: `always`
 - `metric_l1` (Number) Interface metric Level-1.
   - Range: `0`-`16777216`
@@ -114,8 +119,10 @@ resource "nxos_isis_interface" "example" {
 - `mtu_check_l2` (Boolean) MTU Check for IS-IS on Level-2.
   - Default value: `false`
 - `network_type_p2p` (String) Enabling Point-to-Point Network Type on IS-IS Interface.
+  - Choices: `off`, `on`, `useAllISMac`
   - Default value: `off`
 - `passive` (String) IS-IS Passive Interface Info.
+  - Choices: `l1`, `l2`, `l12`, `noL1`, `noL2`, `noL12`, `inheritDef`
   - Default value: `inheritDef`
 - `priority_l1` (Number) Circuit priority.
   - Range: `0`-`127`

--- a/docs/resources/isis_vrf.md
+++ b/docs/resources/isis_vrf.md
@@ -59,6 +59,7 @@ resource "nxos_isis_vrf" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `authentication_check_l1` (Boolean) Authentication Check for ISIS on Level-1.
   - Default value: `true`
@@ -67,24 +68,30 @@ resource "nxos_isis_vrf" "example" {
 - `authentication_key_l1` (String) Authentication Key for IS-IS on Level-1.
 - `authentication_key_l2` (String) Authentication Key for IS-IS on Level-2.
 - `authentication_type_l1` (String) IS-IS Authentication-Type for Level-1.
+  - Choices: `clear`, `md5`, `unknown`
   - Default value: `unknown`
 - `authentication_type_l2` (String) IS-IS Authentication-Type for Level-2.
+  - Choices: `clear`, `md5`, `unknown`
   - Default value: `unknown`
 - `bandwidth_reference` (Number) The IS-IS domain bandwidth reference. This sets the default reference bandwidth used for calculating the IS-IS cost metric.
   - Range: `0`-`4294967295`
   - Default value: `40000`
 - `banwidth_reference_unit` (String) Bandwidth reference unit.
+  - Choices: `mbps`, `gbps`
   - Default value: `mbps`
 - `device` (String) A device name from the provider configuration.
 - `is_type` (String) IS-IS domain type.
+  - Choices: `l1`, `l2`, `l12`
   - Default value: `l12`
 - `metric_type` (String) IS-IS metric type.
+  - Choices: `narrow`, `wide`, `transition`
   - Default value: `wide`
 - `mtu` (Number) The configuration of link-state packet (LSP) maximum transmission units (MTU) is supported. You can enable up to 4352 bytes.
   - Range: `256`-`4352`
   - Default value: `1492`
 - `net` (String) Holds IS-IS domain NET (address) value.
 - `passive_default` (String) IS-IS Domain passive-interface default level.
+  - Choices: `l1`, `l2`, `l12`, `unknown`
   - Default value: `unknown`
 
 ### Read-Only

--- a/docs/resources/ospf.md
+++ b/docs/resources/ospf.md
@@ -33,6 +33,7 @@ resource "nxos_ospf" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `device` (String) A device name from the provider configuration.
 

--- a/docs/resources/ospf_area.md
+++ b/docs/resources/ospf_area.md
@@ -45,12 +45,14 @@ resource "nxos_ospf_area" "example" {
 ### Optional
 
 - `authentication_type` (String) Authentication type.
+  - Choices: `none`, `simple`, `md5`, `unspecified`
   - Default value: `unspecified`
 - `cost` (Number) Area cost, specifies cost for default summary LSAs. Used with nssa/stub area types.
   - Range: `0`-`16777215`
   - Default value: `1`
 - `device` (String) A device name from the provider configuration.
 - `type` (String) Area type.
+  - Choices: `regular`, `stub`, `nssa`
   - Default value: `regular`
 
 ### Read-Only

--- a/docs/resources/ospf_authentication.md
+++ b/docs/resources/ospf_authentication.md
@@ -59,6 +59,7 @@ resource "nxos_ospf_authentication" "example" {
 - `md5_key_secure_mode` (Boolean) Encrypted authentication md5 key or plain text key.
   - Default value: `false`
 - `type` (String) Authentication type.
+  - Choices: `none`, `simple`, `md5`, `unspecified`
   - Default value: `unspecified`
 
 ### Read-Only

--- a/docs/resources/ospf_instance.md
+++ b/docs/resources/ospf_instance.md
@@ -44,6 +44,7 @@ resource "nxos_ospf_instance" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `device` (String) A device name from the provider configuration.
 

--- a/docs/resources/ospf_interface.md
+++ b/docs/resources/ospf_interface.md
@@ -60,6 +60,7 @@ resource "nxos_ospf_interface" "example" {
 - `area` (String) Area identifier to which a network or interface belongs in IPv4 address format.
   - Default value: `0.0.0.0`
 - `bfd` (String) Bidirectional Forwarding Detection (BFD).
+  - Choices: `unspecified`, `enabled`, `disabled`
   - Default value: `unspecified`
 - `cost` (Number) Specifies the cost of interface.
   - Range: `0`-`65535`
@@ -72,8 +73,10 @@ resource "nxos_ospf_interface" "example" {
   - Range: `0`-`65535`
   - Default value: `10`
 - `network_type` (String) Network type.
+  - Choices: `unspecified`, `p2p`, `bcast`
   - Default value: `unspecified`
 - `passive` (String) Passive interface control. Interface can be configured as passive or non-passive.
+  - Choices: `unspecified`, `enabled`, `disabled`
   - Default value: `unspecified`
 - `priority` (Number) Priority, used in determining the designated router on this network.
   - Range: `0`-`255`

--- a/docs/resources/ospf_vrf.md
+++ b/docs/resources/ospf_vrf.md
@@ -57,11 +57,13 @@ resource "nxos_ospf_vrf" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `bandwidth_reference` (Number) Bandwidth reference value.
   - Range: `0`-`4294967295`
   - Default value: `40000`
 - `banwidth_reference_unit` (String) Bandwidth reference unit.
+  - Choices: `mbps`, `gbps`
   - Default value: `mbps`
 - `device` (String) A device name from the provider configuration.
 - `distance` (Number) Administrative distance preference.

--- a/docs/resources/pim.md
+++ b/docs/resources/pim.md
@@ -33,6 +33,7 @@ resource "nxos_pim" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `device` (String) A device name from the provider configuration.
 

--- a/docs/resources/pim_instance.md
+++ b/docs/resources/pim_instance.md
@@ -39,6 +39,7 @@ resource "nxos_pim_instance" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `device` (String) A device name from the provider configuration.
 

--- a/docs/resources/pim_interface.md
+++ b/docs/resources/pim_interface.md
@@ -44,8 +44,10 @@ resource "nxos_pim_interface" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `bfd` (String) BFD.
+  - Choices: `enabled`, `disabled`
   - Default value: `disabled`
 - `device` (String) A device name from the provider configuration.
 - `dr_priority` (Number) Designated Router priority level.

--- a/docs/resources/pim_vrf.md
+++ b/docs/resources/pim_vrf.md
@@ -53,6 +53,7 @@ resource "nxos_pim_vrf" "example" {
 ### Optional
 
 - `admin_state` (String) Administrative state.
+  - Choices: `enabled`, `disabled`
   - Default value: `enabled`
 - `bfd` (Boolean) BFD.
   - Default value: `false`

--- a/docs/resources/queuing_qos_policy_map.md
+++ b/docs/resources/queuing_qos_policy_map.md
@@ -39,6 +39,7 @@ resource "nxos_queuing_qos_policy_map" "example" {
 
 - `device` (String) A device name from the provider configuration.
 - `match_type` (String) Match type.
+  - Choices: `match-any`, `match-all`, `match-first`
   - Default value: `match-all`
 
 ### Read-Only

--- a/gen/definitions/bgp.yaml
+++ b/gen/definitions/bgp.yaml
@@ -12,7 +12,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled

--- a/gen/definitions/bgp_instance.yaml
+++ b/gen/definitions/bgp_instance.yaml
@@ -12,7 +12,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled

--- a/gen/definitions/default_qos_class_map.yaml
+++ b/gen/definitions/default_qos_class_map.yaml
@@ -18,7 +18,7 @@ attributes:
     tf_name: match_type
     type: String
     description: 'Match type.'
-    enum_value:
+    enum_values:
       - match-any
       - match-all
       - match-first

--- a/gen/definitions/default_qos_policy_map.yaml
+++ b/gen/definitions/default_qos_policy_map.yaml
@@ -18,7 +18,7 @@ attributes:
     tf_name: match_type
     type: String
     description: 'Match type.'
-    enum_value:
+    enum_values:
       - match-any
       - match-all
       - match-first

--- a/gen/definitions/feature_bfd.yaml
+++ b/gen/definitions/feature_bfd.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_bgp.yaml
+++ b/gen/definitions/feature_bgp.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_dhcp.yaml
+++ b/gen/definitions/feature_dhcp.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_evpn.yaml
+++ b/gen/definitions/feature_evpn.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_hmm.yaml
+++ b/gen/definitions/feature_hmm.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_hsrp.yaml
+++ b/gen/definitions/feature_hsrp.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_interface_vlan.yaml
+++ b/gen/definitions/feature_interface_vlan.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_isis.yaml
+++ b/gen/definitions/feature_isis.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_lacp.yaml
+++ b/gen/definitions/feature_lacp.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_lldp.yaml
+++ b/gen/definitions/feature_lldp.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_macsec.yaml
+++ b/gen/definitions/feature_macsec.yaml
@@ -13,7 +13,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_netflow.yaml
+++ b/gen/definitions/feature_netflow.yaml
@@ -13,7 +13,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_nv_overlay.yaml
+++ b/gen/definitions/feature_nv_overlay.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_ospf.yaml
+++ b/gen/definitions/feature_ospf.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_ospfv3.yaml
+++ b/gen/definitions/feature_ospfv3.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_pim.yaml
+++ b/gen/definitions/feature_pim.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_ptp.yaml
+++ b/gen/definitions/feature_ptp.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_pvlan.yaml
+++ b/gen/definitions/feature_pvlan.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_ssh.yaml
+++ b/gen/definitions/feature_ssh.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_tacacs.yaml
+++ b/gen/definitions/feature_tacacs.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_telnet.yaml
+++ b/gen/definitions/feature_telnet.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_udld.yaml
+++ b/gen/definitions/feature_udld.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_vn_segment.yaml
+++ b/gen/definitions/feature_vn_segment.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/feature_vpc.yaml
+++ b/gen/definitions/feature_vpc.yaml
@@ -12,7 +12,7 @@ attributes:
     type: String
     mandatory: true
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     example: enabled

--- a/gen/definitions/isis.yaml
+++ b/gen/definitions/isis.yaml
@@ -13,7 +13,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled

--- a/gen/definitions/isis_instance.yaml
+++ b/gen/definitions/isis_instance.yaml
@@ -20,7 +20,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled

--- a/gen/definitions/isis_interface.yaml
+++ b/gen/definitions/isis_interface.yaml
@@ -54,7 +54,7 @@ attributes:
     tf_name: authentication_type
     type: String
     description: 'IS-IS Authentication-Type without specific level.'
-    enum_value:
+    enum_values:
       - clear
       - md5
       - unknown
@@ -64,7 +64,7 @@ attributes:
     tf_name: authentication_type_l1
     type: String
     description: 'IS-IS Authentication-Type for Level-1.'
-    enum_value:
+    enum_values:
       - clear
       - md5
       - unknown
@@ -74,7 +74,7 @@ attributes:
     tf_name: authentication_type_l2
     type: String
     description: 'IS-IS Authentication-Type for Level-2.'
-    enum_value:
+    enum_values:
       - clear
       - md5
       - unknown
@@ -84,7 +84,7 @@ attributes:
     tf_name: circuit_type
     type: String
     description: 'Circuit type.'
-    enum_value:
+    enum_values:
       - l1
       - l2
       - l12
@@ -147,7 +147,7 @@ attributes:
     tf_name: hello_padding
     type: String
     description: 'Hello padding.'
-    enum_value:
+    enum_values:
       - always
       - transient
       - never
@@ -191,7 +191,7 @@ attributes:
     tf_name: network_type_p2p
     type: String
     description: 'Enabling Point-to-Point Network Type on IS-IS Interface.'
-    enum_value:
+    enum_values:
       - 'off'
       - 'on'
       - useAllISMac
@@ -201,7 +201,7 @@ attributes:
     tf_name: passive
     type: String
     description: 'IS-IS Passive Interface Info.'
-    enum_value:
+    enum_values:
       - l1
       - l2
       - l12

--- a/gen/definitions/isis_vrf.yaml
+++ b/gen/definitions/isis_vrf.yaml
@@ -27,7 +27,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled
@@ -60,7 +60,7 @@ attributes:
     tf_name: authentication_type_l1
     type: String
     description: 'IS-IS Authentication-Type for Level-1.'
-    enum_value:
+    enum_values:
       - clear
       - md5
       - unknown
@@ -70,7 +70,7 @@ attributes:
     tf_name: authentication_type_l2
     type: String
     description: 'IS-IS Authentication-Type for Level-2.'
-    enum_value:
+    enum_values:
       - clear
       - md5
       - unknown
@@ -88,7 +88,7 @@ attributes:
     tf_name: banwidth_reference_unit
     type: String
     description: 'Bandwidth reference unit.'
-    enum_value:
+    enum_values:
       - mbps
       - gbps
     default_value: mbps
@@ -97,7 +97,7 @@ attributes:
     tf_name: is_type
     type: String
     description: 'IS-IS domain type.'
-    enum_value:
+    enum_values:
       - l1
       - l2
       - l12
@@ -107,7 +107,7 @@ attributes:
     tf_name: metric_type
     type: String
     description: 'IS-IS metric type.'
-    enum_value:
+    enum_values:
       - narrow
       - wide
       - transition
@@ -130,7 +130,7 @@ attributes:
     tf_name: passive_default
     type: String
     description: 'IS-IS Domain passive-interface default level.'
-    enum_value:
+    enum_values:
       - l1
       - l2
       - l12

--- a/gen/definitions/ospf.yaml
+++ b/gen/definitions/ospf.yaml
@@ -12,7 +12,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled

--- a/gen/definitions/ospf_area.yaml
+++ b/gen/definitions/ospf_area.yaml
@@ -33,7 +33,7 @@ attributes:
     tf_name: authentication_type
     type: String
     description: 'Authentication type.'
-    enum_value:
+    enum_values:
       - none
       - simple
       - md5
@@ -52,7 +52,7 @@ attributes:
     tf_name: type
     type: String
     description: 'Area type.'
-    enum_value:
+    enum_values:
       - regular
       - stub
       - nssa

--- a/gen/definitions/ospf_authentication.yaml
+++ b/gen/definitions/ospf_authentication.yaml
@@ -70,7 +70,7 @@ attributes:
     tf_name: type
     type: String
     description: 'Authentication type.'
-    enum_value:
+    enum_values:
       - none
       - simple
       - md5

--- a/gen/definitions/ospf_instance.yaml
+++ b/gen/definitions/ospf_instance.yaml
@@ -14,7 +14,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled

--- a/gen/definitions/ospf_interface.yaml
+++ b/gen/definitions/ospf_interface.yaml
@@ -46,7 +46,7 @@ attributes:
     tf_name: bfd
     type: String
     description: 'Bidirectional Forwarding Detection (BFD).'
-    enum_value:
+    enum_values:
       - unspecified
       - enabled
       - disabled
@@ -80,7 +80,7 @@ attributes:
     tf_name: network_type
     type: String
     description: 'Network type.'
-    enum_value:
+    enum_values:
       - unspecified
       - p2p
       - bcast
@@ -90,7 +90,7 @@ attributes:
     tf_name: passive
     type: String
     description: 'Passive interface control. Interface can be configured as passive or non-passive.'
-    enum_value:
+    enum_values:
       - unspecified
       - enabled
       - disabled

--- a/gen/definitions/ospf_vrf.yaml
+++ b/gen/definitions/ospf_vrf.yaml
@@ -30,7 +30,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled
@@ -47,7 +47,7 @@ attributes:
     tf_name: banwidth_reference_unit
     type: String
     description: 'Bandwidth reference unit.'
-    enum_value:
+    enum_values:
       - mbps
       - gbps
     default_value: mbps

--- a/gen/definitions/pim.yaml
+++ b/gen/definitions/pim.yaml
@@ -12,7 +12,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled

--- a/gen/definitions/pim_instance.yaml
+++ b/gen/definitions/pim_instance.yaml
@@ -14,7 +14,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled

--- a/gen/definitions/pim_interface.yaml
+++ b/gen/definitions/pim_interface.yaml
@@ -25,7 +25,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled
@@ -34,7 +34,7 @@ attributes:
     tf_name: bfd
     type: String
     description: 'BFD.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: disabled

--- a/gen/definitions/pim_vrf.yaml
+++ b/gen/definitions/pim_vrf.yaml
@@ -24,7 +24,7 @@ attributes:
     tf_name: admin_state
     type: String
     description: 'Administrative state.'
-    enum_value:
+    enum_values:
       - enabled
       - disabled
     default_value: enabled

--- a/gen/definitions/queuing_qos_policy_map.yaml
+++ b/gen/definitions/queuing_qos_policy_map.yaml
@@ -18,7 +18,7 @@ attributes:
     tf_name: match_type
     type: String
     description: 'Match type.'
-    enum_value:
+    enum_values:
       - match-any
       - match-all
       - match-first

--- a/internal/provider/resource_nxos_bgp.go
+++ b/internal/provider/resource_nxos_bgp.go
@@ -37,10 +37,13 @@ func (t resourceBGPType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diag
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},

--- a/internal/provider/resource_nxos_bgp_instance.go
+++ b/internal/provider/resource_nxos_bgp_instance.go
@@ -37,10 +37,13 @@ func (t resourceBGPInstanceType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},

--- a/internal/provider/resource_nxos_default_qos_class_map.go
+++ b/internal/provider/resource_nxos_default_qos_class_map.go
@@ -45,10 +45,13 @@ func (t resourceDefaultQOSClassMapType) GetSchema(ctx context.Context) (tfsdk.Sc
 				},
 			},
 			"match_type": {
-				MarkdownDescription: helpers.NewAttributeDescription("Match type.").AddDefaultValueDescription("match-all").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Match type.").AddStringEnumDescription("match-any", "match-all", "match-first").AddDefaultValueDescription("match-all").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("match-any", "match-all", "match-first"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("match-all"),
 				},

--- a/internal/provider/resource_nxos_default_qos_policy_map.go
+++ b/internal/provider/resource_nxos_default_qos_policy_map.go
@@ -45,10 +45,13 @@ func (t resourceDefaultQOSPolicyMapType) GetSchema(ctx context.Context) (tfsdk.S
 				},
 			},
 			"match_type": {
-				MarkdownDescription: helpers.NewAttributeDescription("Match type.").AddDefaultValueDescription("match-all").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Match type.").AddStringEnumDescription("match-any", "match-all", "match-first").AddDefaultValueDescription("match-all").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("match-any", "match-all", "match-first"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("match-all"),
 				},

--- a/internal/provider/resource_nxos_feature_bfd.go
+++ b/internal/provider/resource_nxos_feature_bfd.go
@@ -37,9 +37,12 @@ func (t resourceFeatureBFDType) GetSchema(ctx context.Context) (tfsdk.Schema, di
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_bgp.go
+++ b/internal/provider/resource_nxos_feature_bgp.go
@@ -37,9 +37,12 @@ func (t resourceFeatureBGPType) GetSchema(ctx context.Context) (tfsdk.Schema, di
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_dhcp.go
+++ b/internal/provider/resource_nxos_feature_dhcp.go
@@ -37,9 +37,12 @@ func (t resourceFeatureDHCPType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_evpn.go
+++ b/internal/provider/resource_nxos_feature_evpn.go
@@ -37,9 +37,12 @@ func (t resourceFeatureEVPNType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_hmm.go
+++ b/internal/provider/resource_nxos_feature_hmm.go
@@ -37,9 +37,12 @@ func (t resourceFeatureHMMType) GetSchema(ctx context.Context) (tfsdk.Schema, di
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_hsrp.go
+++ b/internal/provider/resource_nxos_feature_hsrp.go
@@ -37,9 +37,12 @@ func (t resourceFeatureHSRPType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_interface_vlan.go
+++ b/internal/provider/resource_nxos_feature_interface_vlan.go
@@ -37,9 +37,12 @@ func (t resourceFeatureInterfaceVLANType) GetSchema(ctx context.Context) (tfsdk.
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_isis.go
+++ b/internal/provider/resource_nxos_feature_isis.go
@@ -37,9 +37,12 @@ func (t resourceFeatureISISType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_lacp.go
+++ b/internal/provider/resource_nxos_feature_lacp.go
@@ -37,9 +37,12 @@ func (t resourceFeatureLACPType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_lldp.go
+++ b/internal/provider/resource_nxos_feature_lldp.go
@@ -37,9 +37,12 @@ func (t resourceFeatureLLDPType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_macsec.go
+++ b/internal/provider/resource_nxos_feature_macsec.go
@@ -37,9 +37,12 @@ func (t resourceFeatureMACsecType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_netflow.go
+++ b/internal/provider/resource_nxos_feature_netflow.go
@@ -37,9 +37,12 @@ func (t resourceFeatureNetflowType) GetSchema(ctx context.Context) (tfsdk.Schema
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_nv_overlay.go
+++ b/internal/provider/resource_nxos_feature_nv_overlay.go
@@ -37,9 +37,12 @@ func (t resourceFeatureNVOverlayType) GetSchema(ctx context.Context) (tfsdk.Sche
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_ospf.go
+++ b/internal/provider/resource_nxos_feature_ospf.go
@@ -37,9 +37,12 @@ func (t resourceFeatureOSPFType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_ospfv3.go
+++ b/internal/provider/resource_nxos_feature_ospfv3.go
@@ -37,9 +37,12 @@ func (t resourceFeatureOSPFv3Type) GetSchema(ctx context.Context) (tfsdk.Schema,
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_pim.go
+++ b/internal/provider/resource_nxos_feature_pim.go
@@ -37,9 +37,12 @@ func (t resourceFeaturePIMType) GetSchema(ctx context.Context) (tfsdk.Schema, di
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_ptp.go
+++ b/internal/provider/resource_nxos_feature_ptp.go
@@ -37,9 +37,12 @@ func (t resourceFeaturePTPType) GetSchema(ctx context.Context) (tfsdk.Schema, di
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_pvlan.go
+++ b/internal/provider/resource_nxos_feature_pvlan.go
@@ -37,9 +37,12 @@ func (t resourceFeaturePVLANType) GetSchema(ctx context.Context) (tfsdk.Schema, 
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_ssh.go
+++ b/internal/provider/resource_nxos_feature_ssh.go
@@ -37,9 +37,12 @@ func (t resourceFeatureSSHType) GetSchema(ctx context.Context) (tfsdk.Schema, di
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_tacacs.go
+++ b/internal/provider/resource_nxos_feature_tacacs.go
@@ -37,9 +37,12 @@ func (t resourceFeatureTACACSType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_telnet.go
+++ b/internal/provider/resource_nxos_feature_telnet.go
@@ -37,9 +37,12 @@ func (t resourceFeatureTelnetType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_udld.go
+++ b/internal/provider/resource_nxos_feature_udld.go
@@ -37,9 +37,12 @@ func (t resourceFeatureUDLDType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_vn_segment.go
+++ b/internal/provider/resource_nxos_feature_vn_segment.go
@@ -37,9 +37,12 @@ func (t resourceFeatureVNSegmentType) GetSchema(ctx context.Context) (tfsdk.Sche
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_feature_vpc.go
+++ b/internal/provider/resource_nxos_feature_vpc.go
@@ -37,9 +37,12 @@ func (t resourceFeatureVPCType) GetSchema(ctx context.Context) (tfsdk.Schema, di
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").String,
 				Type:                types.StringType,
 				Required:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 			},
 		},
 	}, nil

--- a/internal/provider/resource_nxos_isis.go
+++ b/internal/provider/resource_nxos_isis.go
@@ -37,10 +37,13 @@ func (t resourceISISType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Dia
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},

--- a/internal/provider/resource_nxos_isis_instance.go
+++ b/internal/provider/resource_nxos_isis_instance.go
@@ -45,10 +45,13 @@ func (t resourceISISInstanceType) GetSchema(ctx context.Context) (tfsdk.Schema, 
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},

--- a/internal/provider/resource_nxos_isis_interface.go
+++ b/internal/provider/resource_nxos_isis_interface.go
@@ -90,37 +90,49 @@ func (t resourceISISInterfaceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				Computed:            true,
 			},
 			"authentication_type": {
-				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type without specific level.").AddDefaultValueDescription("unknown").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type without specific level.").AddStringEnumDescription("clear", "md5", "unknown").AddDefaultValueDescription("unknown").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("clear", "md5", "unknown"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unknown"),
 				},
 			},
 			"authentication_type_l1": {
-				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type for Level-1.").AddDefaultValueDescription("unknown").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type for Level-1.").AddStringEnumDescription("clear", "md5", "unknown").AddDefaultValueDescription("unknown").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("clear", "md5", "unknown"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unknown"),
 				},
 			},
 			"authentication_type_l2": {
-				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type for Level-2.").AddDefaultValueDescription("unknown").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type for Level-2.").AddStringEnumDescription("clear", "md5", "unknown").AddDefaultValueDescription("unknown").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("clear", "md5", "unknown"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unknown"),
 				},
 			},
 			"circuit_type": {
-				MarkdownDescription: helpers.NewAttributeDescription("Circuit type.").AddDefaultValueDescription("l12").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Circuit type.").AddStringEnumDescription("l1", "l2", "l12").AddDefaultValueDescription("l12").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("l1", "l2", "l12"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("l12"),
 				},
@@ -204,10 +216,13 @@ func (t resourceISISInterfaceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				},
 			},
 			"hello_padding": {
-				MarkdownDescription: helpers.NewAttributeDescription("Hello padding.").AddDefaultValueDescription("always").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Hello padding.").AddStringEnumDescription("always", "transient", "never").AddDefaultValueDescription("always").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("always", "transient", "never"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("always"),
 				},
@@ -264,19 +279,25 @@ func (t resourceISISInterfaceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				},
 			},
 			"network_type_p2p": {
-				MarkdownDescription: helpers.NewAttributeDescription("Enabling Point-to-Point Network Type on IS-IS Interface.").AddDefaultValueDescription("off").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Enabling Point-to-Point Network Type on IS-IS Interface.").AddStringEnumDescription("off", "on", "useAllISMac").AddDefaultValueDescription("off").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("off", "on", "useAllISMac"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("off"),
 				},
 			},
 			"passive": {
-				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Passive Interface Info.").AddDefaultValueDescription("inheritDef").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Passive Interface Info.").AddStringEnumDescription("l1", "l2", "l12", "noL1", "noL2", "noL12", "inheritDef").AddDefaultValueDescription("inheritDef").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("l1", "l2", "l12", "noL1", "noL2", "noL12", "inheritDef"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("inheritDef"),
 				},

--- a/internal/provider/resource_nxos_isis_vrf.go
+++ b/internal/provider/resource_nxos_isis_vrf.go
@@ -53,10 +53,13 @@ func (t resourceISISVRFType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},
@@ -92,19 +95,25 @@ func (t resourceISISVRFType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.
 				Computed:            true,
 			},
 			"authentication_type_l1": {
-				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type for Level-1.").AddDefaultValueDescription("unknown").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type for Level-1.").AddStringEnumDescription("clear", "md5", "unknown").AddDefaultValueDescription("unknown").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("clear", "md5", "unknown"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unknown"),
 				},
 			},
 			"authentication_type_l2": {
-				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type for Level-2.").AddDefaultValueDescription("unknown").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Authentication-Type for Level-2.").AddStringEnumDescription("clear", "md5", "unknown").AddDefaultValueDescription("unknown").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("clear", "md5", "unknown"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unknown"),
 				},
@@ -122,28 +131,37 @@ func (t resourceISISVRFType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.
 				},
 			},
 			"banwidth_reference_unit": {
-				MarkdownDescription: helpers.NewAttributeDescription("Bandwidth reference unit.").AddDefaultValueDescription("mbps").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Bandwidth reference unit.").AddStringEnumDescription("mbps", "gbps").AddDefaultValueDescription("mbps").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("mbps", "gbps"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("mbps"),
 				},
 			},
 			"is_type": {
-				MarkdownDescription: helpers.NewAttributeDescription("IS-IS domain type.").AddDefaultValueDescription("l12").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IS-IS domain type.").AddStringEnumDescription("l1", "l2", "l12").AddDefaultValueDescription("l12").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("l1", "l2", "l12"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("l12"),
 				},
 			},
 			"metric_type": {
-				MarkdownDescription: helpers.NewAttributeDescription("IS-IS metric type.").AddDefaultValueDescription("wide").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IS-IS metric type.").AddStringEnumDescription("narrow", "wide", "transition").AddDefaultValueDescription("wide").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("narrow", "wide", "transition"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("wide"),
 				},
@@ -167,10 +185,13 @@ func (t resourceISISVRFType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.
 				Computed:            true,
 			},
 			"passive_default": {
-				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Domain passive-interface default level.").AddDefaultValueDescription("unknown").String,
+				MarkdownDescription: helpers.NewAttributeDescription("IS-IS Domain passive-interface default level.").AddStringEnumDescription("l1", "l2", "l12", "unknown").AddDefaultValueDescription("unknown").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("l1", "l2", "l12", "unknown"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unknown"),
 				},

--- a/internal/provider/resource_nxos_ospf.go
+++ b/internal/provider/resource_nxos_ospf.go
@@ -37,10 +37,13 @@ func (t resourceOSPFType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Dia
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},

--- a/internal/provider/resource_nxos_ospf_area.go
+++ b/internal/provider/resource_nxos_ospf_area.go
@@ -61,10 +61,13 @@ func (t resourceOSPFAreaType) GetSchema(ctx context.Context) (tfsdk.Schema, diag
 				},
 			},
 			"authentication_type": {
-				MarkdownDescription: helpers.NewAttributeDescription("Authentication type.").AddDefaultValueDescription("unspecified").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Authentication type.").AddStringEnumDescription("none", "simple", "md5", "unspecified").AddDefaultValueDescription("unspecified").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("none", "simple", "md5", "unspecified"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unspecified"),
 				},
@@ -82,10 +85,13 @@ func (t resourceOSPFAreaType) GetSchema(ctx context.Context) (tfsdk.Schema, diag
 				},
 			},
 			"type": {
-				MarkdownDescription: helpers.NewAttributeDescription("Area type.").AddDefaultValueDescription("regular").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Area type.").AddStringEnumDescription("regular", "stub", "nssa").AddDefaultValueDescription("regular").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("regular", "stub", "nssa"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("regular"),
 				},

--- a/internal/provider/resource_nxos_ospf_authentication.go
+++ b/internal/provider/resource_nxos_ospf_authentication.go
@@ -109,10 +109,13 @@ func (t resourceOSPFAuthenticationType) GetSchema(ctx context.Context) (tfsdk.Sc
 				},
 			},
 			"type": {
-				MarkdownDescription: helpers.NewAttributeDescription("Authentication type.").AddDefaultValueDescription("unspecified").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Authentication type.").AddStringEnumDescription("none", "simple", "md5", "unspecified").AddDefaultValueDescription("unspecified").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("none", "simple", "md5", "unspecified"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unspecified"),
 				},

--- a/internal/provider/resource_nxos_ospf_instance.go
+++ b/internal/provider/resource_nxos_ospf_instance.go
@@ -37,10 +37,13 @@ func (t resourceOSPFInstanceType) GetSchema(ctx context.Context) (tfsdk.Schema, 
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},

--- a/internal/provider/resource_nxos_ospf_interface.go
+++ b/internal/provider/resource_nxos_ospf_interface.go
@@ -79,10 +79,13 @@ func (t resourceOSPFInterfaceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				},
 			},
 			"bfd": {
-				MarkdownDescription: helpers.NewAttributeDescription("Bidirectional Forwarding Detection (BFD).").AddDefaultValueDescription("unspecified").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Bidirectional Forwarding Detection (BFD).").AddStringEnumDescription("unspecified", "enabled", "disabled").AddDefaultValueDescription("unspecified").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("unspecified", "enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unspecified"),
 				},
@@ -124,19 +127,25 @@ func (t resourceOSPFInterfaceType) GetSchema(ctx context.Context) (tfsdk.Schema,
 				},
 			},
 			"network_type": {
-				MarkdownDescription: helpers.NewAttributeDescription("Network type.").AddDefaultValueDescription("unspecified").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Network type.").AddStringEnumDescription("unspecified", "p2p", "bcast").AddDefaultValueDescription("unspecified").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("unspecified", "p2p", "bcast"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unspecified"),
 				},
 			},
 			"passive": {
-				MarkdownDescription: helpers.NewAttributeDescription("Passive interface control. Interface can be configured as passive or non-passive.").AddDefaultValueDescription("unspecified").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Passive interface control. Interface can be configured as passive or non-passive.").AddStringEnumDescription("unspecified", "enabled", "disabled").AddDefaultValueDescription("unspecified").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("unspecified", "enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("unspecified"),
 				},

--- a/internal/provider/resource_nxos_ospf_vrf.go
+++ b/internal/provider/resource_nxos_ospf_vrf.go
@@ -53,10 +53,13 @@ func (t resourceOSPFVRFType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},
@@ -74,10 +77,13 @@ func (t resourceOSPFVRFType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.
 				},
 			},
 			"banwidth_reference_unit": {
-				MarkdownDescription: helpers.NewAttributeDescription("Bandwidth reference unit.").AddDefaultValueDescription("mbps").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Bandwidth reference unit.").AddStringEnumDescription("mbps", "gbps").AddDefaultValueDescription("mbps").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("mbps", "gbps"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("mbps"),
 				},

--- a/internal/provider/resource_nxos_pim.go
+++ b/internal/provider/resource_nxos_pim.go
@@ -37,10 +37,13 @@ func (t resourcePIMType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diag
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},

--- a/internal/provider/resource_nxos_pim_instance.go
+++ b/internal/provider/resource_nxos_pim_instance.go
@@ -37,10 +37,13 @@ func (t resourcePIMInstanceType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},

--- a/internal/provider/resource_nxos_pim_interface.go
+++ b/internal/provider/resource_nxos_pim_interface.go
@@ -53,19 +53,25 @@ func (t resourcePIMInterfaceType) GetSchema(ctx context.Context) (tfsdk.Schema, 
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},
 			},
 			"bfd": {
-				MarkdownDescription: helpers.NewAttributeDescription("BFD.").AddDefaultValueDescription("disabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("BFD.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("disabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("disabled"),
 				},

--- a/internal/provider/resource_nxos_pim_vrf.go
+++ b/internal/provider/resource_nxos_pim_vrf.go
@@ -45,10 +45,13 @@ func (t resourcePIMVRFType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.D
 				},
 			},
 			"admin_state": {
-				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddDefaultValueDescription("enabled").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Administrative state.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("enabled").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("enabled", "disabled"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("enabled"),
 				},

--- a/internal/provider/resource_nxos_queuing_qos_policy_map.go
+++ b/internal/provider/resource_nxos_queuing_qos_policy_map.go
@@ -45,10 +45,13 @@ func (t resourceQueuingQOSPolicyMapType) GetSchema(ctx context.Context) (tfsdk.S
 				},
 			},
 			"match_type": {
-				MarkdownDescription: helpers.NewAttributeDescription("Match type.").AddDefaultValueDescription("match-all").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Match type.").AddStringEnumDescription("match-any", "match-all", "match-first").AddDefaultValueDescription("match-all").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				Validators: []tfsdk.AttributeValidator{
+					helpers.StringEnumValidator("match-any", "match-all", "match-first"),
+				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					helpers.StringDefaultModifier("match-all"),
 				},


### PR DESCRIPTION
there was a typo in some YAML definitions: ```enum_value:``` instead of ```enum_values:```
Changes made:
```
$ cd gen/definitions
$ grep "enum_values:" * | wc -l
      28
$ grep "enum_value:" * | wc -l 
      60
sed -i "s/    enum_value:/    enum_values:/g" *
$ grep "enum_value:" * | wc -l 
       0
```