### PR TITLE
added requires replace

### DIFF
--- a/gen/definitions/bgp_instance.yaml
+++ b/gen/definitions/bgp_instance.yaml
@@ -22,6 +22,7 @@ attributes:
   - nxos_name: asn
     tf_name: asn
     type: String
+    requires_replace: true
     description: 'Autonomous system number.'
     example: '65001'
 test_prerequisites:

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -90,19 +90,20 @@ type YamlConfig struct {
 }
 
 type YamlConfigAttribute struct {
-	NxosName      string   `yaml:"nxos_name"`
-	TfName        string   `yaml:"tf_name"`
-	Type          string   `yaml:"type"`
-	Id            bool     `yaml:"id"`
-	ReferenceOnly bool     `yaml:"reference_only"`
-	Mandatory     bool     `yaml:"mandatory"`
-	ReadOnly      bool     `yaml:"read_only"`
-	Description   string   `yaml:"description"`
-	Example       string   `yaml:"example"`
-	EnumValues    []string `yaml:"enum_values"`
-	MinInt        int      `yaml:"min_int"`
-	MaxInt        int      `yaml:"max_int"`
-	DefaultValue  string   `yaml:"default_value"`
+	NxosName        string   `yaml:"nxos_name"`
+	TfName          string   `yaml:"tf_name"`
+	Type            string   `yaml:"type"`
+	Id              bool     `yaml:"id"`
+	ReferenceOnly   bool     `yaml:"reference_only"`
+	Mandatory       bool     `yaml:"mandatory"`
+	ReadOnly        bool     `yaml:"read_only"`
+	Description     string   `yaml:"description"`
+	Example         string   `yaml:"example"`
+	EnumValues      []string `yaml:"enum_values"`
+	MinInt          int      `yaml:"min_int"`
+	MaxInt          int      `yaml:"max_int"`
+	DefaultValue    string   `yaml:"default_value"`
+	RequiresReplace bool     `yaml:"requires_replace"`
 }
 
 type YamlTest struct {

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -76,9 +76,9 @@ func (t resource{{camelCase .Name}}Type) GetSchema(ctx context.Context) (tfsdk.S
 					helpers.IntegerRangeValidator({{.MinInt}}, {{.MaxInt}}),
 				},
 				{{- end}}
-				{{- if or (len .DefaultValue) (eq .Id true)}}
+				{{- if or (len .DefaultValue) (eq .Id true) (eq .RequiresReplace true)}}
 				PlanModifiers: tfsdk.AttributePlanModifiers{
-					{{- if eq .Id true}}
+					{{- if or (eq .Id true) (eq .RequiresReplace true)}}
 					tfsdk.RequiresReplace(),
 					{{- else if eq .Type "Int64"}}
 					helpers.IntegerDefaultModifier({{.DefaultValue}}),

--- a/internal/provider/resource_nxos_bgp_instance.go
+++ b/internal/provider/resource_nxos_bgp_instance.go
@@ -53,6 +53,9 @@ func (t resourceBGPInstanceType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					tfsdk.RequiresReplace(),
+				},
 			},
 		},
 	}, nil


### PR DESCRIPTION
`requires_replace` allows to specify attributes which are not ids, but still can not be updates in-place. Example: bgp AS number.