### PR TITLE
Bgp fix

### DIFF
--- a/docs/data-sources/bgp_peer_address_family.md
+++ b/docs/data-sources/bgp_peer_address_family.md
@@ -38,7 +38,9 @@ data "nxos_bgp_peer_address_family" "example" {
 
 ### Read-Only
 
-- `control` (String) Peer address-family control.
+- `control` (String) Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:
+  - Single value. Example: `nh-self`
+  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.
 - `id` (String) The distinguished name of the object.
 - `send_community_extended` (String) Send-community extended.
 - `send_community_standard` (String) Send-community standard.

--- a/docs/data-sources/bgp_peer_template_address_family.md
+++ b/docs/data-sources/bgp_peer_template_address_family.md
@@ -36,7 +36,9 @@ data "nxos_bgp_peer_template_address_family" "example" {
 
 ### Read-Only
 
-- `control` (String) Peer address-family control.
+- `control` (String) Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:
+  - Single value. Example: `nh-self`
+  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.
 - `id` (String) The distinguished name of the object.
 - `send_community_extended` (String) Send-community extended.
 - `send_community_standard` (String) Send-community standard.

--- a/docs/resources/bgp_peer_address_family.md
+++ b/docs/resources/bgp_peer_address_family.md
@@ -46,7 +46,6 @@ resource "nxos_bgp_peer_address_family" "example" {
 ### Optional
 
 - `control` (String) Peer address-family control.
-  - Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`
 - `device` (String) A device name from the provider configuration.
 - `send_community_extended` (String) Send-community extended.
   - Choices: `enabled`, `disabled`

--- a/docs/resources/bgp_peer_address_family.md
+++ b/docs/resources/bgp_peer_address_family.md
@@ -26,7 +26,7 @@ resource "nxos_bgp_peer_address_family" "example" {
   vrf                     = "default"
   address                 = "192.168.0.1"
   address_family          = "ipv4-ucast"
-  control                 = "rr-client"
+  control                 = "nh-self,rr-client"
   send_community_extended = "enabled"
   send_community_standard = "enabled"
 }
@@ -45,7 +45,9 @@ resource "nxos_bgp_peer_address_family" "example" {
 
 ### Optional
 
-- `control` (String) Peer address-family control.
+- `control` (String) Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:
+  - Single value. Example: `nh-self`
+  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.
 - `device` (String) A device name from the provider configuration.
 - `send_community_extended` (String) Send-community extended.
   - Choices: `enabled`, `disabled`

--- a/docs/resources/bgp_peer_template_address_family.md
+++ b/docs/resources/bgp_peer_template_address_family.md
@@ -31,7 +31,7 @@ This resource can manage the BGP peer template address family configuration.
 resource "nxos_bgp_peer_template_address_family" "example" {
   template_name           = "SPINE-PEERS"
   address_family          = "ipv4-ucast"
-  control                 = "rr-client"
+  control                 = "nh-self,rr-client"
   send_community_extended = "enabled"
   send_community_standard = "enabled"
 }
@@ -49,7 +49,9 @@ resource "nxos_bgp_peer_template_address_family" "example" {
 
 ### Optional
 
-- `control` (String) Peer address-family control.
+- `control` (String) Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:
+  - Single value. Example: `nh-self`
+  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.
 - `device` (String) A device name from the provider configuration.
 - `send_community_extended` (String) Send-community extended.
   - Choices: `enabled`, `disabled`

--- a/docs/resources/bgp_peer_template_address_family.md
+++ b/docs/resources/bgp_peer_template_address_family.md
@@ -50,7 +50,6 @@ resource "nxos_bgp_peer_template_address_family" "example" {
 ### Optional
 
 - `control` (String) Peer address-family control.
-  - Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`
 - `device` (String) A device name from the provider configuration.
 - `send_community_extended` (String) Send-community extended.
   - Choices: `enabled`, `disabled`

--- a/examples/resources/nxos_bgp_peer_address_family/resource.tf
+++ b/examples/resources/nxos_bgp_peer_address_family/resource.tf
@@ -2,7 +2,7 @@ resource "nxos_bgp_peer_address_family" "example" {
   vrf                     = "default"
   address                 = "192.168.0.1"
   address_family          = "ipv4-ucast"
-  control                 = "rr-client"
+  control                 = "nh-self,rr-client"
   send_community_extended = "enabled"
   send_community_standard = "enabled"
 }

--- a/examples/resources/nxos_bgp_peer_template_address_family/resource.tf
+++ b/examples/resources/nxos_bgp_peer_template_address_family/resource.tf
@@ -1,7 +1,7 @@
 resource "nxos_bgp_peer_template_address_family" "example" {
   template_name           = "SPINE-PEERS"
   address_family          = "ipv4-ucast"
-  control                 = "rr-client"
+  control                 = "nh-self,rr-client"
   send_community_extended = "enabled"
   send_community_standard = "enabled"
 }

--- a/gen/definitions/bgp_peer_address_family.yaml
+++ b/gen/definitions/bgp_peer_address_family.yaml
@@ -41,7 +41,6 @@ attributes:
     tf_name: control
     type: String
     description: 'Peer address-family control.'
-    default_value: ''
     example: 'rr-client'
   - nxos_name: sendComExt
     tf_name: send_community_extended

--- a/gen/definitions/bgp_peer_address_family.yaml
+++ b/gen/definitions/bgp_peer_address_family.yaml
@@ -41,15 +41,7 @@ attributes:
     tf_name: control
     type: String
     description: 'Peer address-family control.'
-    enum_values:
-      - rr-client
-      - nh-self
-      - dis-peer-as-check
-      - allow-self-as
-      - default-originate
-      - advertisement-interval
-      - suppress-inactive
-      - nh-self-all
+    default_value: ''
     example: 'rr-client'
   - nxos_name: sendComExt
     tf_name: send_community_extended

--- a/gen/definitions/bgp_peer_address_family.yaml
+++ b/gen/definitions/bgp_peer_address_family.yaml
@@ -40,8 +40,8 @@ attributes:
   - nxos_name: ctrl
     tf_name: control
     type: String
-    description: 'Peer address-family control.'
-    example: 'rr-client'
+    description: 'Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:\n  - Single value. Example: `nh-self`\n  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.'
+    example: 'nh-self,rr-client'
   - nxos_name: sendComExt
     tf_name: send_community_extended
     type: String

--- a/gen/definitions/bgp_peer_template_address_family.yaml
+++ b/gen/definitions/bgp_peer_template_address_family.yaml
@@ -35,8 +35,8 @@ attributes:
   - nxos_name: ctrl
     tf_name: control
     type: String
-    description: 'Peer address-family control.'
-    example: 'rr-client'
+    description: 'Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:\n  - Single value. Example: `nh-self`\n  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.'
+    example: 'nh-self,rr-client'
   - nxos_name: sendComExt
     tf_name: send_community_extended
     type: String

--- a/gen/definitions/bgp_peer_template_address_family.yaml
+++ b/gen/definitions/bgp_peer_template_address_family.yaml
@@ -36,7 +36,6 @@ attributes:
     tf_name: control
     type: String
     description: 'Peer address-family control.'
-    default_value: ''
     example: 'rr-client'
   - nxos_name: sendComExt
     tf_name: send_community_extended

--- a/gen/definitions/bgp_peer_template_address_family.yaml
+++ b/gen/definitions/bgp_peer_template_address_family.yaml
@@ -36,15 +36,7 @@ attributes:
     tf_name: control
     type: String
     description: 'Peer address-family control.'
-    enum_values:
-      - rr-client
-      - nh-self
-      - dis-peer-as-check
-      - allow-self-as
-      - default-originate
-      - advertisement-interval
-      - suppress-inactive
-      - nh-self-all
+    default_value: ''
     example: 'rr-client'
   - nxos_name: sendComExt
     tf_name: send_community_extended

--- a/internal/provider/data_source_nxos_bgp_peer_address_family.go
+++ b/internal/provider/data_source_nxos_bgp_peer_address_family.go
@@ -48,7 +48,7 @@ func (t dataSourceBGPPeerAddressFamilyType) GetSchema(ctx context.Context) (tfsd
 				Required:            true,
 			},
 			"control": {
-				MarkdownDescription: "Peer address-family control.",
+				MarkdownDescription: "Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:\n  - Single value. Example: `nh-self`\n  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.",
 				Type:                types.StringType,
 				Computed:            true,
 			},

--- a/internal/provider/data_source_nxos_bgp_peer_address_family_test.go
+++ b/internal/provider/data_source_nxos_bgp_peer_address_family_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNxosBGPPeerAddressFamily(t *testing.T) {
 				Config: testAccDataSourceNxosBGPPeerAddressFamilyPrerequisitesConfig + testAccDataSourceNxosBGPPeerAddressFamilyConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.nxos_bgp_peer_address_family.test", "address_family", "ipv4-ucast"),
-					resource.TestCheckResourceAttr("data.nxos_bgp_peer_address_family.test", "control", "rr-client"),
+					resource.TestCheckResourceAttr("data.nxos_bgp_peer_address_family.test", "control", "nh-self,rr-client"),
 					resource.TestCheckResourceAttr("data.nxos_bgp_peer_address_family.test", "send_community_extended", "enabled"),
 					resource.TestCheckResourceAttr("data.nxos_bgp_peer_address_family.test", "send_community_standard", "enabled"),
 				),
@@ -81,7 +81,7 @@ resource "nxos_bgp_peer_address_family" "test" {
   vrf = "default"
   address = "192.168.0.1"
   address_family = "ipv4-ucast"
-  control = "rr-client"
+  control = "nh-self,rr-client"
   send_community_extended = "enabled"
   send_community_standard = "enabled"
   depends_on = [nxos_rest.PreReq0, nxos_rest.PreReq1, nxos_rest.PreReq2, nxos_rest.PreReq3, nxos_rest.PreReq4, ]

--- a/internal/provider/data_source_nxos_bgp_peer_template_address_family.go
+++ b/internal/provider/data_source_nxos_bgp_peer_template_address_family.go
@@ -43,7 +43,7 @@ func (t dataSourceBGPPeerTemplateAddressFamilyType) GetSchema(ctx context.Contex
 				Required:            true,
 			},
 			"control": {
-				MarkdownDescription: "Peer address-family control.",
+				MarkdownDescription: "Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:\n  - Single value. Example: `nh-self`\n  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.",
 				Type:                types.StringType,
 				Computed:            true,
 			},

--- a/internal/provider/data_source_nxos_bgp_peer_template_address_family_test.go
+++ b/internal/provider/data_source_nxos_bgp_peer_template_address_family_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNxosBGPPeerTemplateAddressFamily(t *testing.T) {
 				Config: testAccDataSourceNxosBGPPeerTemplateAddressFamilyPrerequisitesConfig + testAccDataSourceNxosBGPPeerTemplateAddressFamilyConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.nxos_bgp_peer_template_address_family.test", "address_family", "ipv4-ucast"),
-					resource.TestCheckResourceAttr("data.nxos_bgp_peer_template_address_family.test", "control", "rr-client"),
+					resource.TestCheckResourceAttr("data.nxos_bgp_peer_template_address_family.test", "control", "nh-self,rr-client"),
 					resource.TestCheckResourceAttr("data.nxos_bgp_peer_template_address_family.test", "send_community_extended", "enabled"),
 					resource.TestCheckResourceAttr("data.nxos_bgp_peer_template_address_family.test", "send_community_standard", "enabled"),
 				),
@@ -79,7 +79,7 @@ const testAccDataSourceNxosBGPPeerTemplateAddressFamilyConfig = `
 resource "nxos_bgp_peer_template_address_family" "test" {
   template_name = "SPINE-PEERS"
   address_family = "ipv4-ucast"
-  control = "rr-client"
+  control = "nh-self,rr-client"
   send_community_extended = "enabled"
   send_community_standard = "enabled"
   depends_on = [nxos_rest.PreReq0, nxos_rest.PreReq1, nxos_rest.PreReq2, nxos_rest.PreReq3, nxos_rest.PreReq4, ]

--- a/internal/provider/resource_nxos_bgp_peer_address_family.go
+++ b/internal/provider/resource_nxos_bgp_peer_address_family.go
@@ -64,13 +64,10 @@ func (t resourceBGPPeerAddressFamilyType) GetSchema(ctx context.Context) (tfsdk.
 				},
 			},
 			"control": {
-				MarkdownDescription: helpers.NewAttributeDescription("Peer address-family control.").AddStringEnumDescription("rr-client", "nh-self", "dis-peer-as-check", "allow-self-as", "default-originate", "advertisement-interval", "suppress-inactive", "nh-self-all").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Peer address-family control.").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
-				Validators: []tfsdk.AttributeValidator{
-					helpers.StringEnumValidator("rr-client", "nh-self", "dis-peer-as-check", "allow-self-as", "default-originate", "advertisement-interval", "suppress-inactive", "nh-self-all"),
-				},
 			},
 			"send_community_extended": {
 				MarkdownDescription: helpers.NewAttributeDescription("Send-community extended.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("disabled").String,

--- a/internal/provider/resource_nxos_bgp_peer_address_family.go
+++ b/internal/provider/resource_nxos_bgp_peer_address_family.go
@@ -64,7 +64,7 @@ func (t resourceBGPPeerAddressFamilyType) GetSchema(ctx context.Context) (tfsdk.
 				},
 			},
 			"control": {
-				MarkdownDescription: helpers.NewAttributeDescription("Peer address-family control.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:\n  - Single value. Example: `nh-self`\n  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,

--- a/internal/provider/resource_nxos_bgp_peer_address_family_test.go
+++ b/internal/provider/resource_nxos_bgp_peer_address_family_test.go
@@ -19,7 +19,7 @@ func TestAccNxosBGPPeerAddressFamily(t *testing.T) {
 					resource.TestCheckResourceAttr("nxos_bgp_peer_address_family.test", "vrf", "default"),
 					resource.TestCheckResourceAttr("nxos_bgp_peer_address_family.test", "address", "192.168.0.1"),
 					resource.TestCheckResourceAttr("nxos_bgp_peer_address_family.test", "address_family", "ipv4-ucast"),
-					resource.TestCheckResourceAttr("nxos_bgp_peer_address_family.test", "control", "rr-client"),
+					resource.TestCheckResourceAttr("nxos_bgp_peer_address_family.test", "control", "nh-self,rr-client"),
 					resource.TestCheckResourceAttr("nxos_bgp_peer_address_family.test", "send_community_extended", "enabled"),
 					resource.TestCheckResourceAttr("nxos_bgp_peer_address_family.test", "send_community_standard", "enabled"),
 				),
@@ -99,7 +99,7 @@ func testAccNxosBGPPeerAddressFamilyConfig_all() string {
 		vrf = "default"
 		address = "192.168.0.1"
 		address_family = "ipv4-ucast"
-		control = "rr-client"
+		control = "nh-self,rr-client"
 		send_community_extended = "enabled"
 		send_community_standard = "enabled"
   		depends_on = [nxos_rest.PreReq0, nxos_rest.PreReq1, nxos_rest.PreReq2, nxos_rest.PreReq3, nxos_rest.PreReq4, ]

--- a/internal/provider/resource_nxos_bgp_peer_template_address_family.go
+++ b/internal/provider/resource_nxos_bgp_peer_template_address_family.go
@@ -56,13 +56,10 @@ func (t resourceBGPPeerTemplateAddressFamilyType) GetSchema(ctx context.Context)
 				},
 			},
 			"control": {
-				MarkdownDescription: helpers.NewAttributeDescription("Peer address-family control.").AddStringEnumDescription("rr-client", "nh-self", "dis-peer-as-check", "allow-self-as", "default-originate", "advertisement-interval", "suppress-inactive", "nh-self-all").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Peer address-family control.").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,
-				Validators: []tfsdk.AttributeValidator{
-					helpers.StringEnumValidator("rr-client", "nh-self", "dis-peer-as-check", "allow-self-as", "default-originate", "advertisement-interval", "suppress-inactive", "nh-self-all"),
-				},
 			},
 			"send_community_extended": {
 				MarkdownDescription: helpers.NewAttributeDescription("Send-community extended.").AddStringEnumDescription("enabled", "disabled").AddDefaultValueDescription("disabled").String,

--- a/internal/provider/resource_nxos_bgp_peer_template_address_family.go
+++ b/internal/provider/resource_nxos_bgp_peer_template_address_family.go
@@ -56,7 +56,7 @@ func (t resourceBGPPeerTemplateAddressFamilyType) GetSchema(ctx context.Context)
 				},
 			},
 			"control": {
-				MarkdownDescription: helpers.NewAttributeDescription("Peer address-family control.").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Peer address-family control. Choices: `rr-client`, `nh-self`, `dis-peer-as-check`, `allow-self-as`, `default-originate`, `advertisement-interval`, `suppress-inactive`, `nh-self-all`. Can be an empty string. Allowed formats:\n  - Single value. Example: `nh-self`\n  - Multiple values (comma-separated). Example: `dis-peer-as-check,nh-self,rr-client,suppress-inactive`. In this case values must be in alphabetical order.").String,
 				Type:                types.StringType,
 				Optional:            true,
 				Computed:            true,

--- a/internal/provider/resource_nxos_bgp_peer_template_address_family_test.go
+++ b/internal/provider/resource_nxos_bgp_peer_template_address_family_test.go
@@ -18,7 +18,7 @@ func TestAccNxosBGPPeerTemplateAddressFamily(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("nxos_bgp_peer_template_address_family.test", "template_name", "SPINE-PEERS"),
 					resource.TestCheckResourceAttr("nxos_bgp_peer_template_address_family.test", "address_family", "ipv4-ucast"),
-					resource.TestCheckResourceAttr("nxos_bgp_peer_template_address_family.test", "control", "rr-client"),
+					resource.TestCheckResourceAttr("nxos_bgp_peer_template_address_family.test", "control", "nh-self,rr-client"),
 					resource.TestCheckResourceAttr("nxos_bgp_peer_template_address_family.test", "send_community_extended", "enabled"),
 					resource.TestCheckResourceAttr("nxos_bgp_peer_template_address_family.test", "send_community_standard", "enabled"),
 				),
@@ -95,7 +95,7 @@ func testAccNxosBGPPeerTemplateAddressFamilyConfig_all() string {
 	resource "nxos_bgp_peer_template_address_family" "test" {
 		template_name = "SPINE-PEERS"
 		address_family = "ipv4-ucast"
-		control = "rr-client"
+		control = "nh-self,rr-client"
 		send_community_extended = "enabled"
 		send_community_standard = "enabled"
   		depends_on = [nxos_rest.PreReq0, nxos_rest.PreReq1, nxos_rest.PreReq2, nxos_rest.PreReq3, nxos_rest.PreReq4, ]


### PR DESCRIPTION
Currently we set `control` to choices: rr-client, nh-self, dis-peer-as-check, allow-self-as, default-originate, advertisement-interval, suppress-inactive, nh-self-all.
Actually it can be list of values above:
```
"ctrl": "nh-self,rr-client",
```
Or it could be empty value:
```
"ctrl": "",
```

So, deleted `enum_values`.